### PR TITLE
Select Fix

### DIFF
--- a/src/components/Form/Select/index.js
+++ b/src/components/Form/Select/index.js
@@ -24,6 +24,12 @@ class Select extends Component {
       options: []
    }
 
+   componentDidMount() {
+      if (!this.props.value && this.props.options.length) {
+         this.props.triggerChange(null, this.props.options[0].value)
+      }
+   }
+
    handleBlur = (event) => {
       this.props.triggerValidation()
 


### PR DESCRIPTION
If no value is passed in to select, then the select will use the first option that was passed in as it's val until the user changes the value or the form is submitted

OIO Form needs to be substantially re-written for V2.